### PR TITLE
memfd: fix configure test

### DIFF
--- a/configure
+++ b/configure
@@ -3570,7 +3570,7 @@ fi
 # check if memfd is supported
 memfd=no
 cat > $TMPC << EOF
-#include <sys/memfd.h>
+#include <sys/mman.h>
 
 int main(void)
 {

--- a/util/memfd.c
+++ b/util/memfd.c
@@ -34,9 +34,7 @@
 
 #include "qemu/memfd.h"
 
-#ifdef CONFIG_MEMFD
-#include <sys/memfd.h>
-#elif defined CONFIG_LINUX
+#if defined CONFIG_LINUX && !defined CONFIG_MEMFD
 #include <sys/syscall.h>
 #include <asm/unistd.h>
 


### PR DESCRIPTION
Fix the compilation problem in current Ubuntu release:

    /builddir/build/BUILD/qemu-2.11.0-rc1/util/memfd.c:40:12: error: static declaration of memfd_create follows non-static declaration

Cherry-picked from 75e5b70e6b5dcc4f2219992d7cffa462aa406af0, see:

https://git.qemu.org/?p=qemu.git;a=commit;h=75e5b70e6b5dcc4f2219992d7cffa462aa406af0